### PR TITLE
Make default public only & exported only

### DIFF
--- a/src/default/assets/js/src/typedoc/components/Filter.ts
+++ b/src/default/assets/js/src/typedoc/components/Filter.ts
@@ -65,7 +65,7 @@ namespace typedoc
 
         protected handleValueChange(oldValue:boolean, newValue:boolean) {
             this.$checkbox.prop('checked', this.value);
-            $html.toggleClass('toggle-' + this.key, this.value != this.defaultValue);
+            $html.toggleClass('toggle-' + this.key);
         }
 
 

--- a/src/default/assets/js/src/typedoc/components/Filter.ts
+++ b/src/default/assets/js/src/typedoc/components/Filter.ts
@@ -139,10 +139,10 @@ namespace typedoc
         constructor(options?:Backbone.ViewOptions<any>) {
             super(options);
 
-            this.optionVisibility   = new FilterItemSelect('visibility',      'private');
+            this.optionVisibility   = new FilterItemSelect('visibility',      'public');
             this.optionInherited    = new FilterItemCheckbox('inherited',     true);
             this.optionExternals    = new FilterItemCheckbox('externals',     true);
-            this.optionOnlyExported = new FilterItemCheckbox('only-exported', false);
+            this.optionOnlyExported = new FilterItemCheckbox('only-exported', true);
         }
 
 

--- a/src/default/assets/js/src/typedoc/components/Filter.ts
+++ b/src/default/assets/js/src/typedoc/components/Filter.ts
@@ -16,13 +16,16 @@ namespace typedoc
 
         constructor(key:string, value:T) {
             this.key = key;
-            this.value = value;
+            this.value = value; //I'd delete this, but I can't
             this.defaultValue = value;
 
             this.initialize();
 
             if (window.localStorage[this.key]) {
                 this.setValue(this.fromLocalStorage(window.localStorage[this.key]));
+            }
+            else {
+                this.setValue(this.value);
             }
         }
 
@@ -38,8 +41,6 @@ namespace typedoc
 
 
         protected setValue(value:T) {
-            if (this.value == value) return;
-
             var oldValue = this.value;
             this.value = value;
             window.localStorage[this.key] = this.toLocalStorage(value);
@@ -150,6 +151,7 @@ namespace typedoc
             try {
                 return typeof window.localStorage != 'undefined';
             } catch (e) {
+                console.log("no local storage");
                 return false;
             }
         }

--- a/src/default/partials/header.hbs
+++ b/src/default/partials/header.hbs
@@ -21,11 +21,11 @@
                         <a href="#" class="tsd-widget options no-caption" data-toggle="options">Options</a>
                         <div class="tsd-filter-group">
                             <div class="tsd-select" id="tsd-filter-visibility">
-                                <span class="tsd-select-label">All</span>
+                                <span class="tsd-select-label">Public</span>
                                 <ul class="tsd-select-list">
-                                    <li data-value="public">Public</li>
+                                    <li data-value="public" class="selected">Public</li>
                                     <li data-value="protected">Public/Protected</li>
-                                    <li data-value="private" class="selected">All</li>
+                                    <li data-value="private">All</li>
                                 </ul>
                             </div>
 
@@ -38,7 +38,7 @@
                             {{/unless}}
 
                             {{#unless settings.excludeNotExported}}
-                                <input type="checkbox" id="tsd-filter-only-exported" />
+                                <input type="checkbox" id="tsd-filter-only-exported" checked />
                                 <label class="tsd-widget" for="tsd-filter-only-exported">Only exported</label>
                             {{/unless}}
                         </div>


### PR DESCRIPTION
This PR alters the default settings to be public only and exported only.

To do this it is not sufficient to just change the defaults in the constructors, because it turns out that the constructors also don't work very well.  So I had to make the constructors (and some other things) work a bit more robustly.